### PR TITLE
provide souffle-mode, not souffle

### DIFF
--- a/souffle-mode.el
+++ b/souffle-mode.el
@@ -21,7 +21,7 @@
     table))
 
 (setq souffle-highlights
-      '((":-\\|=\\|:\\|\\[\\|\\]\\|\\.type\\|\\.decl\\|\\.comp\\|\\.init\\|\\." . font-lock-keyword-face)
+      '((":-\\|=\\|:\\|\\[\\|\\]\\|\\.type\\|\\.decl\\|\\.comp\\|\\.init\\|\\.input\\|\\.output\\|\\." . font-lock-keyword-face)
         ("\\number\\|symbol" . font-lock-builtin-face)
         (":" . font-lock-constant-face)))
 

--- a/souffle-mode.el
+++ b/souffle-mode.el
@@ -34,4 +34,4 @@
   (setq-local comment-end "")
 )
 
-(provide 'souffle)
+(provide 'souffle-mode)


### PR DESCRIPTION
When I do `(require souffle-mode)` with the project as is, I get errors from emacs since it never provides `souffle-mode`. But if I do `(require souffle)`, it doesn't work because file has the wrong name. =)