### PR TITLE
Extend font locking.

### DIFF
--- a/souffle-mode.el
+++ b/souffle-mode.el
@@ -10,7 +10,6 @@
 ;;; Commentary:
 
 ;; Emacs integration for Souffle datalog files
-;; Requires Emacs 24>
 
 ;;; Code:
 
@@ -39,7 +38,7 @@
     "Souffle builtin string functions.")
 
 (defconst souffle-aggregation-functions
-    (list "min" "max" "sum"  "count")
+    (list "min" "max" "sum" "count")
     "Souffle builtin aggregation functions.")
 
 (defconst souffle-types
@@ -75,7 +74,9 @@
 
 
 
-
+;;;;;;;;;;;;;;;;;;;;;;;
+;; define major mode ;;
+;;;;;;;;;;;;;;;;;;;;;;;
 (define-derived-mode souffle-mode prog-mode "souffle"
   "major mode for editing Souffle datalog files."
     :syntax-table souffle-mode-syntax-table
@@ -86,6 +87,8 @@
     (setq-local comment-end "")
  )
 
+
+(add-to-list 'auto-mode-alist '("\\.dl\\'" . souffle-mode))
 
 (provide 'souffle-mode)
 

--- a/souffle-mode.el
+++ b/souffle-mode.el
@@ -42,12 +42,12 @@
     "Souffle builtin aggregation functions.")
 
 (defconst souffle-types
-    (list "symbol" "number")
+    (list "symbol" "number" "unsigned" "float")
     "Souffle builtin types.")
 
 (defconst souffle-highlights
     (let* (
-              ;; Generate regexp fox each category.
+              ;; Generate regexp for each category.
               (souffle-dot-keywords-regexp
                   (concat
                       "\\.\\("

--- a/souffle-mode.el
+++ b/souffle-mode.el
@@ -10,28 +10,83 @@
 ;;; Commentary:
 
 ;; Emacs integration for Souffle datalog files
+;; Requires Emacs 24>
 
 ;;; Code:
 
-(defconst souffle-mode-syntax-table
-  (let ((table (make-syntax-table)))
-    (modify-syntax-entry ?/ "< 1" table)
-    (modify-syntax-entry ?/ "< 2" table)
-    (modify-syntax-entry ?\n "> " table)
-    table))
 
-(setq souffle-highlights
-      '((":-\\|=\\|:\\|\\[\\|\\]\\|\\.type\\|\\.decl\\|\\.comp\\|\\.init\\|\\.input\\|\\.output\\|\\." . font-lock-keyword-face)
-        ("\\number\\|symbol" . font-lock-builtin-face)
-        (":" . font-lock-constant-face)))
+
+(defconst souffle-mode-syntax-table
+    (let ((table (make-syntax-table)))
+        (modify-syntax-entry ?/ "< 1" table)
+        (modify-syntax-entry ?/ "< 2" table)
+        (modify-syntax-entry ?\n "> " table)
+        table)
+    "Souffle mode syntax table.")
+
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Souffle font locks start here ;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defconst souffle-dot-keywords
+    (list "type" "decl" "comp" "init" "input" "output" "number_type" "symbol_type" "override" "printsize")
+    "Souffle keywords that start with a dot.")
+
+(defconst souffle-string-functions
+    (list "cat" "contains" "match" "ord" "strlen" "substr" "to_number" "to_string")
+    "Souffle builtin string functions.")
+
+(defconst souffle-aggregation-functions
+    (list "min" "max" "sum"  "count")
+    "Souffle builtin aggregation functions.")
+
+(defconst souffle-types
+    (list "symbol" "number")
+    "Souffle builtin types.")
+
+(defconst souffle-highlights
+    (let* (
+              ;; Generate regexp fox each category.
+              (souffle-dot-keywords-regexp
+                  (concat
+                      "\\.\\("
+                      (regexp-opt souffle-dot-keywords 'symbols)
+                      "\\)"))
+
+              (souffle-string-fuctions-regexp
+                  (regexp-opt souffle-string-functions 'symbols))
+
+              (souffle-aggregation-functions-regexp
+                  (regexp-opt souffle-aggregation-functions 'symbols))
+
+              (souffle-types-regexp
+                  (regexp-opt souffle-types 'symbols))
+            )
+
+        `(
+             (,souffle-dot-keywords-regexp . font-lock-keyword-face)
+             (,souffle-string-fuctions-regexp . font-lock-function-name-face)
+             (,souffle-aggregation-functions-regexp . font-lock-function-name-face)
+             (,souffle-types-regexp . font-lock-type-face)
+             )
+        ))
+
+
+
 
 (define-derived-mode souffle-mode prog-mode "souffle"
   "major mode for editing Souffle datalog files."
-  :syntax-table souffle-mode-syntax-table
-  (setq font-lock-defaults '(souffle-highlights))
+    :syntax-table souffle-mode-syntax-table
+  
+    (setq font-lock-defaults '(souffle-highlights))
+    
+    (setq-local comment-start "\/\/")
+    (setq-local comment-end "")
+ )
 
-  (setq-local comment-start "\/\/")
-  (setq-local comment-end "")
-)
 
 (provide 'souffle-mode)
+
+;;; souffle-mode.el ends here


### PR DESCRIPTION
- Rewrite of font locking. 
   I've rewritten regexs' into separate lists. They should be easier to extend in the future.
   I also added some keywords (string manipulation and aggregation) and removed some (such as ":-" "[" "]") 
- Inherit from prog-mode instead of fundamental-mode
- Autoload for files with extensions ".dl"