### PR TITLE
Derive souffle-mode from prog-mode

### DIFF
--- a/souffle-mode.el
+++ b/souffle-mode.el
@@ -25,7 +25,7 @@
         ("\\number\\|symbol" . font-lock-builtin-face)
         (":" . font-lock-constant-face)))
 
-(define-derived-mode souffle-mode fundamental-mode "souffle"
+(define-derived-mode souffle-mode prog-mode "souffle"
   "major mode for editing Souffle datalog files."
   :syntax-table souffle-mode-syntax-table
   (setq font-lock-defaults '(souffle-highlights))


### PR DESCRIPTION
See the Emacs manual, section "Basic Major Modes", which states:

> As far as possible, new major modes should be derived, either directly or indirectly, from one of these three modes.

https://www.gnu.org/software/emacs/manual/html_node/elisp/Basic-Major-Modes.html