### PR TITLE
Add "autoload" comments to `souffle-mode` and `auto-mode-alist`

### DIFF
--- a/souffle-mode.el
+++ b/souffle-mode.el
@@ -191,6 +191,8 @@ May be used with Company using the `company-capf' backend."
 ;;;;;;;;;;;;;;;;;;;;;;;
 ;; define major mode ;;
 ;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;###autoload
 (define-derived-mode souffle-mode prog-mode "souffle"
   "Major mode for editing Souffle datalog files."
     :syntax-table souffle-mode-syntax-table
@@ -206,6 +208,7 @@ May be used with Company using the `company-capf' backend."
               'append))
 
 
+;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.dl\\'" . souffle-mode))
 
 (provide 'souffle-mode)


### PR DESCRIPTION
This is standard practice. Fixes #9.